### PR TITLE
Bug/edit after create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 - (Keep your changes here until you have a release version)
 
+## [1.0.30] - 2020-10-26
+### Fixed
+- Bug that prevented users from editing some activities right after they are created
+
 ## [1.0.29] - 2020-10-22
 ### Added
 - Filters for Org, OPR, and keyword search added to the WAR, MAR, and HistoryReport pages

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weekly-activity-report",
   "homepage": ".",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "private": true,
   "dependencies": {
     "@fluentui/react": "^7.105.9",

--- a/src/utilities/ActivityUtilities.ts
+++ b/src/utilities/ActivityUtilities.ts
@@ -50,10 +50,11 @@ export default class ActivityUtilities {
 			// Updated item - set etag on the activity
 			newActivity.__metadata = { etag: ('"' + res.data['odata.etag'].split(',')[1]) };
 		} else {
-			// New item - set Id, WeekOf, and etag
+			// New item - set Id, WeekOf, author, and etag
 			newActivity.Id = res.data.Id;
 			newActivity.WeekOf = res.data.WeekOf;
 			newActivity.__metadata = { etag: res.data.__metadata.etag };
+			newActivity.AuthorId = res.data.AuthorId;
 		}
 		return newActivity;
 	}

--- a/src/utilities/RoleUtilities.ts
+++ b/src/utilities/RoleUtilities.ts
@@ -68,9 +68,11 @@ export default class RoleUtilities {
     static isActivityEditable(activity: IActivity, user: IUserRole) {
         let isNew = activity.Id < 0;
         let userIsAuthor = activity.AuthorId && parseInt(activity.AuthorId) === parseInt(user.Id);
-        let userIsOPR = !activity.OPRs || activity.OPRs.results.some(info => parseInt(info.Id) === parseInt(user.Id));
+        let userIsOPR = activity.OPRs && activity.OPRs.results.some(info => parseInt(info.Id) === parseInt(user.Id));
+        // newly created activities don't have the OPRs field so we need to check the OPRsId field as well
+        let userIsOPRId = activity.OPRsId && activity.OPRsId.results.some(id => id === parseInt(user.Id));
         let userHasRights = activity.Branch && user.UsersRoles.some(role => activity.Branch.includes(role.department));
-        return isNew || userIsAuthor || userIsOPR || userHasRights;
+        return isNew || userIsAuthor || userIsOPR || userIsOPRId || userHasRights;
     }
 
     /**


### PR DESCRIPTION
To recreate the issue, you must create an activity and not include yourself in the OPR list, save it, and then try to edit it immediately after saving. You will be unable to edit the activity, until you refresh the page. You can also recreate the issue if you create an activity for which you are not the first person in the OPR list, so if you delete your own name from the OPR list, and then put someone else, and then add yourself again, the same behavior occurs.